### PR TITLE
Added Co-Developer GPT engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [TypeScript Local Code Plugin](https://github.com/kesor/chatgpt-code-plugin) Localhost plugin for ChatGPT that lets it read your files from your computer
 - [ChatGPT Widescreen Mode](https://chatgptwidescreen.com) 🖥️ Add Widescreen + Fullscreen modes to ChatGPT for enhanced viewing
 - [ChatGPT Infinity](https://chatgptinfinity.com) ∞ Generate endless answers from all-knowing ChatGPT (in any language!)
+- [Co-Developer GPT engine](https://github.com/stoerr/CoDeveloperGPTengine) - provides local r/w file access from ChatGPT chat as GPT actions or ChatGPT plugin, incl. execution of configured actions on your own machine.
 
 ## Web applications
 


### PR DESCRIPTION
The free Co-Developer GPT engine serves in OpenAI GPTs and as ChatGPT plugin to give ChatGPT in the chat the ability to
modify the files in the directory it is started in, and thus makes it possible to discuss code without copying and
pasting it there, and to let ChatGPT write code / modify, even run build actions fixing problems until they work.

https://CoDeveloperGPTengine.stoerr.net/
https://github.com/stoerr/CoDeveloperGPTengine
https://www.youtube.com/watch?v=ubBhv2PUSEs

Language: Java
Licence: Apache-2.0
